### PR TITLE
`Ubuntu-20.04` --> `Ubuntu-22.04`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11.0, 3.12.0]
+        os: [ubuntu-22.04]
+        python-version: [3.7, 3.8, 3.9, 3.10.5, 3.11.0, 3.12.0, 3.13.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/Notebooks/README.md
+++ b/Notebooks/README.md
@@ -8,7 +8,7 @@
 <table style="border-collapse: collapse;">
 	<tr>
 		<td align="center">CI</td>
-		<td align="center"><img src="https://github.com/ECSIM/dbfc-dataset/workflows/CI/badge.svg?branch=master"></td>
+		<td align="center"><img src="https://github.com/ECSIM/dbfc-dataset/actions/workflows/test.yml/badge.svg?branch=master"></td>
 	</tr>
 </table>
 


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- `Ubuntu-20.04` --> `Ubuntu-22.04`
- CI badge bug fixed

#### Any other comments?

